### PR TITLE
feat: refactor event leaderboard and data fetching logic

### DIFF
--- a/src/app/dashboard/page.tsx
+++ b/src/app/dashboard/page.tsx
@@ -5,26 +5,38 @@ import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs"
 import { EventLeaderboard } from "@/components/eventLeaderboard2"
 import { EventSelector } from "@/components/eventselector"
 import Header from "@/components/header"
-import { FACULTY_OPTIONS } from "@/types/constants"
+import { EVENTS, FACULTY_OPTIONS } from "@/types/constants"
 import { supabase } from "@/lib/supabase"
+import { Points, Event } from "@/types/events"
 
 
 
 export default function Home() {
-    const [selectedEvent, setSelectedEvent] = useState("25free")
-    const [points, setPoints] = useState<any[]>([]);
-    const [overallPoints, setOverallPoints] = useState<any[]>([]);
+    const [selectedEvent, setSelectedEvent] = useState("25free");
+    const [menPoint, setMenPoints] = useState<Points[]>([]);
+    const [womenPoints, setWomenPoints] = useState<Points[]>([]);
+    const [eventPoints, setEventPoints] = useState<Points[]>([]);
+    const [overallPoints, setOverallPoints] = useState<Points[]>([]);
+    const [menResults, setMenResults] = useState<Event[]>([]);
+    const [womenResults, setWomenResults] = useState<Event[]>([]);
+    const [allResults, setAllResults] = useState<Event[]>([]);
 
     const fetchData = async () => {
 
         const { data, error } = await supabase
             .from('swims')
             .select('*')
+            .order('points', { ascending: false });
 
         if (error) {
             console.error('Error fetching data:', error)
             return
         }
+        setAllResults(data);
+
+        const menEventId = EVENTS.find((event) => event.key === `M${selectedEvent}`)?.id;
+        const womenEventId = EVENTS.find((event) => event.key === `W${selectedEvent}`)?.id;
+
 
         const facultyPoints = FACULTY_OPTIONS.map(faculty => ({
             name: faculty.key,
@@ -33,12 +45,35 @@ export default function Home() {
                 .reduce((sum, item) => sum + (item.points || 0), 0)
         })).sort((a, b) => b.points - a.points);
 
-        setOverallPoints(facultyPoints)
+        setOverallPoints(facultyPoints);
+
+        // const menPoints = FACULTY_OPTIONS.map(faculty => ({
+        //     name: faculty.key,
+        //     points: data
+        //         .filter(item => item.faculty_id === faculty.id && item.event_id === menEventId)
+        //         .reduce((sum, item) => sum + (item.points || 0), 0)
+        // })).sort((a, b) => b.points - a.points);
+
+        // setMenPoints(menPoints)
+
+        // const womenPoints = FACULTY_OPTIONS.map(faculty => ({
+        //     name: faculty.key,
+        //     points: data
+        //         .filter(item => item.faculty_id === faculty.id && item.event_id === womenEventId)
+        //         .reduce((sum, item) => sum + (item.points || 0), 0)
+        // })).sort((a, b) => b.points - a.points);
+        // setWomenPoints(womenPoints)
+
+        const menResults = data.filter(item => item.event_id === menEventId);
+        setMenResults(menResults);
+        const womenResults = data.filter(item => item.event_id === womenEventId);
+        setWomenResults(womenResults);
     }
+
 
     useEffect(() => {
         fetchData();
-    }, [])
+    }, [selectedEvent]);
 
     return (
         <div className="flex flex-col">
@@ -54,15 +89,23 @@ export default function Home() {
                         <TabsContent value="men">
                             <EventLeaderboard
                                 selectedEvent={selectedEvent}
-                                type="men"
-                                setPoints={setPoints}
+                                results={menResults}
+                                allResults={allResults}
+                                setResults={setMenResults}
+                                setEventPoints={setEventPoints}
+                                overallPoints={overallPoints}
+                                setOverallPoints={setOverallPoints}
                             />
                         </TabsContent>
                         <TabsContent value="women">
                             <EventLeaderboard
                                 selectedEvent={selectedEvent}
-                                type="women"
-                                setPoints={setPoints}
+                                results={womenResults}
+                                allResults={allResults}
+                                setResults={setWomenResults}
+                                setEventPoints={setEventPoints}
+                                overallPoints={overallPoints}
+                                setOverallPoints={setOverallPoints}
                             />
                         </TabsContent>
                     </Tabs>
@@ -77,7 +120,7 @@ export default function Home() {
                             <FacultyLeaderboard leaderboard="event" selectedEvent={selectedEvent} data={overallPoints} />
                         </TabsContent>
                         <TabsContent value="event">
-                            <FacultyLeaderboard leaderboard="event" selectedEvent={selectedEvent} data={points} />
+                            <FacultyLeaderboard leaderboard="event" selectedEvent={selectedEvent} data={eventPoints} />
                         </TabsContent>
                     </Tabs>
 
@@ -106,3 +149,4 @@ export default function Home() {
         </div>
     )
 }
+

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,23 +1,83 @@
 "use client"
-import { useState } from "react"
+import { useEffect, useState } from "react"
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import { EventLeaderboard } from "@/components/eventLeaderboard2";
 import Header from "@/components/header";
 import { EventSelector } from "@/components/eventselector";
+import { supabase } from "@/lib/supabase";
+import { EVENTS, FACULTY_OPTIONS } from "@/types/constants";
+import { Points, Event } from "@/types/events";
 
 
 export default function Home() {
-    const [selectedEvent, setSelectedEvent] = useState("25free")
-    const handleEventSelect = (value: string) => {
-        setSelectedEvent(value.replace(/^[MW]/, ""))
+    const [selectedEvent, setSelectedEvent] = useState("25free");
+    const [menPoint, setMenPoints] = useState<Points[]>([]);
+    const [womenPoints, setWomenPoints] = useState<Points[]>([]);
+    const [eventPoints, setEventPoints] = useState<Points[]>([]);
+    const [overallPoints, setOverallPoints] = useState<Points[]>([]);
+    const [menResults, setMenResults] = useState<Event[]>([]);
+    const [womenResults, setWomenResults] = useState<Event[]>([]);
+    const [allResults, setAllResults] = useState<Event[]>([]);
+
+    const fetchData = async () => {
+
+        const { data, error } = await supabase
+            .from('swims')
+            .select('*')
+            .order('points', { ascending: false });
+
+        if (error) {
+            console.error('Error fetching data:', error)
+            return
+        }
+
+        const menEventId = EVENTS.find((event) => event.key === `M${selectedEvent}`)?.id;
+        const womenEventId = EVENTS.find((event) => event.key === `W${selectedEvent}`)?.id;
+
+
+        const facultyPoints = FACULTY_OPTIONS.map(faculty => ({
+            name: faculty.key,
+            points: data
+                .filter(item => item.faculty_id === faculty.id)
+                .reduce((sum, item) => sum + (item.points || 0), 0)
+        })).sort((a, b) => b.points - a.points);
+
+        setOverallPoints(facultyPoints);
+
+        // const menPoints = FACULTY_OPTIONS.map(faculty => ({
+        //     name: faculty.key,
+        //     points: data
+        //         .filter(item => item.faculty_id === faculty.id && item.event_id === menEventId)
+        //         .reduce((sum, item) => sum + (item.points || 0), 0)
+        // })).sort((a, b) => b.points - a.points);
+
+        // setMenPoints(menPoints)
+
+        // const womenPoints = FACULTY_OPTIONS.map(faculty => ({
+        //     name: faculty.key,
+        //     points: data
+        //         .filter(item => item.faculty_id === faculty.id && item.event_id === womenEventId)
+        //         .reduce((sum, item) => sum + (item.points || 0), 0)
+        // })).sort((a, b) => b.points - a.points);
+        // setWomenPoints(womenPoints)
+
+        const menResults = data.filter(item => item.event_id === menEventId);
+        setMenResults(menResults);
+        const womenResults = data.filter(item => item.event_id === womenEventId);
+        setWomenResults(womenResults);
     }
+
+
+    useEffect(() => {
+        fetchData();
+    }, []);
 
     return (
         <div className="flex flex-col">
             <Header />
             <main className="flex flex-1 gap-4 overflow-auto p-4">
                 <div className="flex w-full max-w-3xl h-fit flex-col rounded-xl bg-muted/50 p-4">
-                    <EventSelector selectedEvent={selectedEvent} onEventSelect={handleEventSelect} />
+                    <EventSelector selectedEvent={selectedEvent} onEventSelect={setSelectedEvent} />
                     <Tabs defaultValue="men" className="relative">
                         <TabsList className="justify-evenly">
                             <TabsTrigger className="text-xs md:text-sm" value="men">Men</TabsTrigger>
@@ -26,13 +86,23 @@ export default function Home() {
                         <TabsContent value="men">
                             <EventLeaderboard
                                 selectedEvent={selectedEvent}
-                                type="men"
+                                results={menResults}
+                                allResults={allResults}
+                                setResults={setMenResults}
+                                setEventPoints={setEventPoints}
+                                overallPoints={overallPoints}
+                                setOverallPoints={setOverallPoints}
                             />
                         </TabsContent>
                         <TabsContent value="women">
                             <EventLeaderboard
                                 selectedEvent={selectedEvent}
-                                type="women"
+                                results={menResults}
+                                allResults={allResults}
+                                setResults={setMenResults}
+                                setEventPoints={setEventPoints}
+                                overallPoints={overallPoints}
+                                setOverallPoints={setOverallPoints}
                             />
                         </TabsContent>
                     </Tabs>

--- a/src/components/facultyleaderboard2.tsx
+++ b/src/components/facultyleaderboard2.tsx
@@ -8,10 +8,6 @@ import {
     TableRow,
 } from "@/components/ui/table"
 import { Badge } from "@/components/ui/badge";
-import { EVENTS } from "@/types/constants";
-import { useEffect, useState } from "react";
-import { supabase } from "@/lib/supabase";
-import { resultdata } from "@/constants";
 
 
 interface FacultyLeaderboardProps {
@@ -35,7 +31,7 @@ export function FacultyLeaderboard({ type, leaderboard, selectedEvent, data }: F
             </TableHeader>
             <TableBody>
                 {data?.map((faculty, index) => (
-                    <TableRow key={index}>
+                    faculty.points > 0 ? (<TableRow key={index}>
                         <TableCell className="px-3 text-xs flex justify-center md:justify-start md:text-sm md:px-6">{index + 1}</TableCell>
                         <TableCell className="px-3 md:px-4">
                             <Badge variant="secondary" className="text-xs md:text-sm">
@@ -43,7 +39,7 @@ export function FacultyLeaderboard({ type, leaderboard, selectedEvent, data }: F
                             </Badge>
                         </TableCell>
                         <TableCell className="px-3 text-xs md:text-sm md:px-4">{faculty.points}</TableCell>
-                    </TableRow>
+                    </TableRow>) : null
                 ))}
             </TableBody>
         </Table>

--- a/src/types/events.ts
+++ b/src/types/events.ts
@@ -7,12 +7,7 @@ export interface Event {
     points?: number
 }
 
-export interface Relay {
-    id: string
-    event_id?: number
-    faculty_id?: number
-    faculty: string
-    time: string
-    points?: number
+export interface Points {
+    name: string,
+    points: number
 }
-


### PR DESCRIPTION
Refactor the EventLeaderboard to accept new props for 
results and allResults, improving data handling. Update the Home 
component to manage additional state for men and women points, 
event points, and results. Enhance data fetching by ordering 
results by points and integrating new event IDs. Add console 
logging for updated results to aid in debugging.