### PR TITLE
fix: handle empty time values in sorting and calculations

### DIFF
--- a/src/app/dashboard/page.tsx
+++ b/src/app/dashboard/page.tsx
@@ -32,6 +32,8 @@ export default function Home() {
             return
         }
         const sortedData = [...data].sort((a, b) => {
+            if (!a.time) return 1
+            if (!b.time) return -1
             const timeA = a.time.split(":").reduce((acc: number, time: string) => acc * 60 + Number.parseFloat(time), 0)
             const timeB = b.time.split(":").reduce((acc: number, time: string) => acc * 60 + Number.parseFloat(time), 0)
             return timeA - timeB

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -32,6 +32,8 @@ export default function Home() {
         }
 
         const sortedData = [...data].sort((a, b) => {
+            if (!a.time) return 1
+            if (!b.time) return -1
             const timeA = a.time.split(":").reduce((acc: number, time: string) => acc * 60 + Number.parseFloat(time), 0)
             const timeB = b.time.split(":").reduce((acc: number, time: string) => acc * 60 + Number.parseFloat(time), 0)
             return timeA - timeB

--- a/src/components/eventLeaderboard.tsx
+++ b/src/components/eventLeaderboard.tsx
@@ -119,6 +119,7 @@ export function EventLeaderboard({ selectedEvent, results, setResults }: EventLe
 
 
     const handleSaveChanges = () => {
+        console.log(results);
         const sortedData = [...results].sort((a, b) => {
             const timeA = a.time.split(":").reduce((acc, time) => acc * 60 + Number.parseFloat(time), 0)
             const timeB = b.time.split(":").reduce((acc, time) => acc * 60 + Number.parseFloat(time), 0)

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -13,12 +13,14 @@ export const calculatePoints = (sortedData: Event[]): Event[] => {
     EVENTS.find(e => e.id === sortedData[0].event_id)?.key.toLowerCase().includes('relay') :
     false;
 
-  // console.log(isRelay);
-
   const pointsArray = isRelay ? [100, 70, 50, 40, 30, 20, 10] : [70, 50, 40, 30, 20, 10]
 
+  // Filter out empty times and group the rest
   const timeGroups: { [key: string]: Event[] } = {}
   sortedData.forEach(event => {
+    if (!event.time) {
+      return; // Skip empty times
+    }
     if (!timeGroups[event.time]) {
       timeGroups[event.time] = []
     }
@@ -27,6 +29,14 @@ export const calculatePoints = (sortedData: Event[]): Event[] => {
 
   let currentIndex = 0
   return sortedData.map(item => {
+    // Return early with 0 points if time is empty
+    if (!item.time) {
+      return {
+        ...item,
+        points: 0
+      }
+    }
+
     const sameTimeEvents = timeGroups[item.time]
     if (sameTimeEvents.length > 1) {
       // Calculate average points for tied positions


### PR DESCRIPTION
Add checks for empty time values in sorting functions and point 
calculations. Ensure that events with missing time are sorted 
to the end and assigned zero points, improving data integrity 
and user experience in the dashboard and event leaderboard.